### PR TITLE
feat: add quotations API

### DIFF
--- a/Tine_Energie/backend/src/app.ts
+++ b/Tine_Energie/backend/src/app.ts
@@ -1,10 +1,15 @@
 import express from 'express';
+import quotationsRouter from './modules/quotations/quotations.route';
 
 const app = express();
+
+app.use(express.json());
 
 app.get('/api/hello', (_req, res) => {
   res.json({ message: 'Hello from TypeScript backend!' });
 });
+
+app.use('/api/quotations', quotationsRouter);
 
 export default app;
 

--- a/Tine_Energie/backend/src/modules/quotations/quotations.route.ts
+++ b/Tine_Energie/backend/src/modules/quotations/quotations.route.ts
@@ -1,0 +1,47 @@
+import { Router } from 'express';
+import {
+  createQuotation,
+  listQuotations,
+  updateQuotationStatus,
+  verifyRecaptcha,
+} from './quotations.service';
+
+const router = Router();
+
+router.post('/', async (req, res) => {
+  const { name, email, message, recaptchaToken } = req.body;
+  if (!name || !email || !message || !recaptchaToken) {
+    return res.status(400).json({ error: 'Missing required fields' });
+  }
+
+  const recaptchaValid = await verifyRecaptcha(recaptchaToken);
+  if (!recaptchaValid) {
+    return res.status(400).json({ error: 'Invalid reCAPTCHA token' });
+  }
+
+  const quotation = await createQuotation({ name, email, message });
+  res.status(201).json(quotation);
+});
+
+router.get('/', async (_req, res) => {
+  const quotations = await listQuotations();
+  res.json(quotations);
+});
+
+router.put('/:id', async (req, res) => {
+  const id = Number(req.params.id);
+  const { status } = req.body;
+
+  if (!['pending', 'approved', 'rejected'].includes(status)) {
+    return res.status(400).json({ error: 'Invalid status' });
+  }
+
+  const quotation = await updateQuotationStatus(id, status);
+  if (!quotation) {
+    return res.status(404).json({ error: 'Quotation not found' });
+  }
+
+  res.json(quotation);
+});
+
+export default router;

--- a/Tine_Energie/backend/src/modules/quotations/quotations.service.ts
+++ b/Tine_Energie/backend/src/modules/quotations/quotations.service.ts
@@ -1,0 +1,60 @@
+export interface Quotation {
+  id: number;
+  name: string;
+  email: string;
+  message: string;
+  status: 'pending' | 'approved' | 'rejected';
+}
+
+let quotations: Quotation[] = [];
+let currentId = 1;
+
+export async function verifyRecaptcha(token: string): Promise<boolean> {
+  const secret = process.env.RECAPTCHA_SECRET;
+  if (!secret) {
+    return false;
+  }
+
+  const params = new URLSearchParams();
+  params.append('secret', secret);
+  params.append('response', token);
+
+  try {
+    const response = await fetch('https://www.google.com/recaptcha/api/siteverify', {
+      method: 'POST',
+      body: params,
+    });
+
+    if (!response.ok) {
+      return false;
+    }
+
+    const data = await response.json();
+    return data.success === true;
+  } catch (_err) {
+    return false;
+  }
+}
+
+export async function createQuotation(data: { name: string; email: string; message: string }): Promise<Quotation> {
+  const quotation: Quotation = {
+    id: currentId++,
+    status: 'pending',
+    ...data,
+  };
+
+  quotations.push(quotation);
+  return quotation;
+}
+
+export async function listQuotations(): Promise<Quotation[]> {
+  return quotations;
+}
+
+export async function updateQuotationStatus(id: number, status: Quotation['status']): Promise<Quotation | undefined> {
+  const quotation = quotations.find((q) => q.id === id);
+  if (quotation) {
+    quotation.status = status;
+  }
+  return quotation;
+}

--- a/Tine_Energie/backend/tsconfig.json
+++ b/Tine_Energie/backend/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "dist",
     "esModuleInterop": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "lib": ["es2019", "dom"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- add quotations service with reCAPTCHA verification
- expose public POST and admin GET/PUT endpoints
- wire quotations routes into Express app

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689232991a0083319ca3d778194bcb59