### PR TITLE
feat: add message endpoints

### DIFF
--- a/Tine_Energie/backend/src/app.ts
+++ b/Tine_Energie/backend/src/app.ts
@@ -1,6 +1,10 @@
 import express from 'express';
+import messagesRouter from './modules/messages';
 
 const app = express();
+
+app.use(express.json());
+app.use('/api/messages', messagesRouter);
 
 app.get('/api/hello', (_req, res) => {
   res.json({ message: 'Hello from TypeScript backend!' });

--- a/Tine_Energie/backend/src/modules/messages/index.ts
+++ b/Tine_Energie/backend/src/modules/messages/index.ts
@@ -1,0 +1,45 @@
+import { Router, Request, Response } from 'express';
+
+export interface Message {
+  name: string;
+  email: string;
+  content: string;
+  date: string;
+}
+
+const messages: Message[] = [];
+const router = Router();
+
+router.post('/', (req: Request, res: Response) => {
+  const { name, email, content, captcha } = req.body as {
+    name?: string;
+    email?: string;
+    content?: string;
+    captcha?: string;
+  };
+
+  const expectedCaptcha = process.env.CAPTCHA_SECRET || '42';
+  if (captcha !== expectedCaptcha) {
+    return res.status(400).json({ error: 'Invalid captcha' });
+  }
+
+  if (!name || !email || !content) {
+    return res.status(400).json({ error: 'Missing required fields' });
+  }
+
+  const message: Message = { name, email, content, date: new Date().toISOString() };
+  messages.push(message);
+  return res.status(201).json({ success: true });
+});
+
+router.get('/', (req: Request, res: Response) => {
+  const adminToken = process.env.ADMIN_TOKEN;
+  const token = req.headers['x-admin-token'] as string | undefined;
+  if (adminToken && token !== adminToken) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  return res.json(messages);
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- add messages module with in-memory store and captcha validation
- expose public POST /api/messages and admin GET /api/messages
- wire module into Express app

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6892329ba7d48331bc286c379c00198a