### PR TITLE
Cache Prisma client to prevent connection leaks

### DIFF
--- a/Tine_Energie/backend/src/prisma/client.ts
+++ b/Tine_Energie/backend/src/prisma/client.ts
@@ -1,0 +1,17 @@
+import { PrismaClient } from '@prisma/client';
+
+// Ensure PrismaClient is reused across hot reloads to prevent
+// exhausting database connections. During development, we attach the
+// client instance to globalThis so it's reused if the module is
+// re-imported.
+const globalForPrisma = globalThis as unknown as {
+  prisma: PrismaClient | undefined;
+};
+
+const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== 'production') {
+  globalForPrisma.prisma = prisma;
+}
+
+export default prisma;


### PR DESCRIPTION
## Summary
- cache the PrismaClient on `globalThis` to reuse connections during hot reloads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68923b2913b88331bf1fb92fcc1a4258