### PR TITLE
feat: use env database url

### DIFF
--- a/Tine_Energie/backend/.env.example
+++ b/Tine_Energie/backend/.env.example
@@ -1,4 +1,5 @@
 PORT=3001
+# Database connection URL
 DATABASE_URL=postgres://user:password@localhost:5432/mydb
 JWT_SECRET=your_jwt_secret
 SMTP_HOST=smtp.example.com

--- a/Tine_Energie/backend/prisma/schema.prisma
+++ b/Tine_Energie/backend/prisma/schema.prisma
@@ -1,0 +1,8 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}


### PR DESCRIPTION
## Summary
- add Prisma schema using DATABASE_URL environment variable
- document DATABASE_URL in example env file

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68923b2842008331ac5e025ef76a7048