### PR TITLE
Add SMTP email notifications for quotations and messages

### DIFF
--- a/Tine_Energie/backend/package-lock.json
+++ b/Tine_Energie/backend/package-lock.json
@@ -8,11 +8,13 @@
       "name": "backend",
       "version": "1.0.0",
       "dependencies": {
-        "express": "^4.18.2"
+        "express": "^4.18.2",
+        "nodemailer": "^7.0.5"
       },
       "devDependencies": {
         "@types/express": "^4.17.17",
         "@types/node": "^20.12.7",
+        "@types/nodemailer": "^6.4.17",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.4.2"
       }
@@ -155,6 +157,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
+      "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -1060,6 +1072,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.5.tgz",
+      "integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/normalize-path": {

--- a/Tine_Energie/backend/package.json
+++ b/Tine_Energie/backend/package.json
@@ -10,11 +10,13 @@
     "test": "echo \"No tests specified\""
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "nodemailer": "^7.0.5"
   },
   "devDependencies": {
     "@types/express": "^4.17.17",
     "@types/node": "^20.12.7",
+    "@types/nodemailer": "^6.4.17",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.4.2"
   }

--- a/Tine_Energie/backend/src/app.ts
+++ b/Tine_Energie/backend/src/app.ts
@@ -1,10 +1,16 @@
 import express from 'express';
+import quotationRouter from './modules/quotations';
+import messageRouter from './modules/messages';
 
 const app = express();
+
+app.use(express.json());
+
+app.use('/api/quotations', quotationRouter);
+app.use('/api/messages', messageRouter);
 
 app.get('/api/hello', (_req, res) => {
   res.json({ message: 'Hello from TypeScript backend!' });
 });
 
 export default app;
-

--- a/Tine_Energie/backend/src/modules/messages.ts
+++ b/Tine_Energie/backend/src/modules/messages.ts
@@ -1,0 +1,32 @@
+import { Router } from 'express';
+import { sendEmail } from '../utils/email';
+import { clientMessage, adminMessage } from '../templates/message';
+
+const router = Router();
+
+router.post('/', async (req, res) => {
+  const { name, email } = req.body as { name: string; email: string };
+
+  try {
+    const client = clientMessage(name);
+    await sendEmail({
+      to: email,
+      subject: 'Votre message a été reçu',
+      ...client,
+    });
+
+    const admin = adminMessage(name);
+    const adminEmail = process.env.ADMIN_EMAIL || email;
+    await sendEmail({
+      to: adminEmail,
+      subject: 'Nouveau message',
+      ...admin,
+    });
+
+    res.json({ status: 'sent' });
+  } catch (err) {
+    res.status(500).json({ error: 'Unable to send email' });
+  }
+});
+
+export default router;

--- a/Tine_Energie/backend/src/modules/quotations.ts
+++ b/Tine_Energie/backend/src/modules/quotations.ts
@@ -1,0 +1,32 @@
+import { Router } from 'express';
+import { sendEmail } from '../utils/email';
+import { clientQuotation, adminQuotation } from '../templates/quotation';
+
+const router = Router();
+
+router.post('/', async (req, res) => {
+  const { name, email } = req.body as { name: string; email: string };
+
+  try {
+    const client = clientQuotation(name);
+    await sendEmail({
+      to: email,
+      subject: 'Votre demande de devis',
+      ...client,
+    });
+
+    const admin = adminQuotation(name);
+    const adminEmail = process.env.ADMIN_EMAIL || email;
+    await sendEmail({
+      to: adminEmail,
+      subject: 'Nouvelle demande de devis',
+      ...admin,
+    });
+
+    res.json({ status: 'sent' });
+  } catch (err) {
+    res.status(500).json({ error: 'Unable to send email' });
+  }
+});
+
+export default router;

--- a/Tine_Energie/backend/src/templates/message.ts
+++ b/Tine_Energie/backend/src/templates/message.ts
@@ -1,0 +1,9 @@
+export const clientMessage = (name: string) => ({
+  text: `Bonjour ${name},\nNous avons bien reçu votre message.`,
+  html: `<p>Bonjour ${name},</p><p>Nous avons bien reçu votre message.</p>`,
+});
+
+export const adminMessage = (name: string) => ({
+  text: `Nouveau message de ${name}.`,
+  html: `<p>Nouveau message de <strong>${name}</strong>.</p>`,
+});

--- a/Tine_Energie/backend/src/templates/quotation.ts
+++ b/Tine_Energie/backend/src/templates/quotation.ts
@@ -1,0 +1,9 @@
+export const clientQuotation = (name: string) => ({
+  text: `Bonjour ${name},\nMerci pour votre demande de devis.`,
+  html: `<p>Bonjour ${name},</p><p>Merci pour votre demande de devis.</p>`,
+});
+
+export const adminQuotation = (name: string) => ({
+  text: `Nouvelle demande de devis de ${name}.`,
+  html: `<p>Nouvelle demande de devis de <strong>${name}</strong>.</p>`,
+});

--- a/Tine_Energie/backend/src/utils/email.ts
+++ b/Tine_Energie/backend/src/utils/email.ts
@@ -1,0 +1,25 @@
+import nodemailer from 'nodemailer';
+
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST,
+  port: Number(process.env.SMTP_PORT) || 587,
+  secure: false,
+  auth: {
+    user: process.env.SMTP_USER,
+    pass: process.env.SMTP_PASS,
+  },
+});
+
+export interface MailContent {
+  to: string;
+  subject: string;
+  text: string;
+  html: string;
+}
+
+export function sendEmail(options: MailContent) {
+  return transporter.sendMail({
+    from: process.env.SMTP_FROM || process.env.SMTP_USER,
+    ...options,
+  });
+}


### PR DESCRIPTION
## Summary
- initialize SMTP email service
- add templates and notifications for quotations and messages

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689232a1d80c8331aba77a06ea36feac