### PR TITLE
fix: resolve package-lock conflict

### DIFF
--- a/Tine_Energie/backend/package-lock.json
+++ b/Tine_Energie/backend/package-lock.json
@@ -529,7 +529,6 @@
       "version": "17.2.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
       "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
-      "devOptional": false,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"


### PR DESCRIPTION
## Summary
- remove stale `devOptional` field from `dotenv` entry in `package-lock.json`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892a0d238548331a71884c7f0248843