### PR TITLE
Check JWT secret env var and drop default secret

### DIFF
--- a/Tine_Energie/backend/src/config/env.ts
+++ b/Tine_Energie/backend/src/config/env.ts
@@ -3,6 +3,10 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
+if (!process.env.JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is not defined');
+}
+
 const envSchema = z.object({
   PORT: z.coerce.number().default(3001),
   DATABASE_URL: z.string().min(1),

--- a/Tine_Energie/backend/src/middleware/auth.ts
+++ b/Tine_Energie/backend/src/middleware/auth.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
+import env from '../config/env';
 
 interface AuthRequest extends Request {
   user?: any;
@@ -12,7 +13,7 @@ export function auth(req: AuthRequest, res: Response, next: NextFunction) {
   }
   const token = authHeader.split(' ')[1];
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    const decoded = jwt.verify(token, env.JWT_SECRET);
     req.user = decoded;
     return next();
   } catch (err) {

--- a/Tine_Energie/backend/src/modules/auth/index.ts
+++ b/Tine_Energie/backend/src/modules/auth/index.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
+import env from '../../config/env';
 
 interface User {
   id: number;
@@ -42,7 +43,7 @@ router.post('/login', async (req, res) => {
   }
   const token = jwt.sign(
     { id: user.id, role: user.role },
-    process.env.JWT_SECRET || 'secret',
+    env.JWT_SECRET,
     { expiresIn: '1h' },
   );
   return res.json({ token });


### PR DESCRIPTION
## Summary
- Remove default `'secret'` JWT fallback and use configured environment secret
- Fail fast at startup if `JWT_SECRET` is not provided

## Testing
- `npm test`
- `npm run build`
- `node dist/index.js` (fails as expected without JWT secret)


------
https://chatgpt.com/codex/tasks/task_e_68936803a7848331924d1f21820bd531