### PR TITLE
Validate Bearer token structure

### DIFF
--- a/Tine_Energie/backend/src/middleware/auth.ts
+++ b/Tine_Energie/backend/src/middleware/auth.ts
@@ -7,10 +7,14 @@ interface AuthRequest extends Request {
 
 export function auth(req: AuthRequest, res: Response, next: NextFunction) {
   const authHeader = req.headers.authorization;
-  if (!authHeader) {
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return res.status(401).json({ message: 'Token required' });
   }
+
   const token = authHeader.split(' ')[1];
+  if (!token) {
+    return res.status(401).json({ message: 'Token required' });
+  }
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
     req.user = decoded;


### PR DESCRIPTION
## Summary
- ensure Authorization header starts with `Bearer `
- verify token segment exists before decoding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893680980608331b53e1070523652d3