### PR TITLE
feat: add JwtPayload interface for auth middleware

### DIFF
--- a/Tine_Energie/backend/src/middleware/auth.ts
+++ b/Tine_Energie/backend/src/middleware/auth.ts
@@ -1,8 +1,9 @@
 import { Request, Response, NextFunction } from 'express';
 import jwt from 'jsonwebtoken';
+import { JwtPayload } from '../types';
 
-interface AuthRequest extends Request {
-  user?: any;
+export interface AuthRequest extends Request {
+  user?: JwtPayload;
 }
 
 export function auth(req: AuthRequest, res: Response, next: NextFunction) {
@@ -12,7 +13,7 @@ export function auth(req: AuthRequest, res: Response, next: NextFunction) {
   }
   const token = authHeader.split(' ')[1];
   try {
-    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret');
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'secret') as JwtPayload;
     req.user = decoded;
     return next();
   } catch (err) {

--- a/Tine_Energie/backend/src/modules/auth/index.ts
+++ b/Tine_Energie/backend/src/modules/auth/index.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
+import { JwtPayload } from '../../types';
 
 interface User {
   id: number;
@@ -40,8 +41,9 @@ router.post('/login', async (req, res) => {
   if (!match) {
     return res.status(401).json({ message: 'Invalid credentials' });
   }
+  const payload: JwtPayload = { id: user.id, role: user.role };
   const token = jwt.sign(
-    { id: user.id, role: user.role },
+    payload,
     process.env.JWT_SECRET || 'secret',
     { expiresIn: '1h' },
   );

--- a/Tine_Energie/backend/src/types.ts
+++ b/Tine_Energie/backend/src/types.ts
@@ -1,0 +1,5 @@
+export interface JwtPayload {
+  id: number;
+  role: string;
+}
+


### PR DESCRIPTION
## Summary
- define JwtPayload type for JWT contents
- type AuthRequest and auth middleware with JwtPayload
- use JwtPayload when generating tokens

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893680c96bc8331a373f6ed58f374db