### PR TITLE
feat: check existing username on register

### DIFF
--- a/Tine_Energie/backend/src/modules/auth/index.ts
+++ b/Tine_Energie/backend/src/modules/auth/index.ts
@@ -19,6 +19,10 @@ router.post('/register', async (req, res) => {
   if (!username || !password) {
     return res.status(400).json({ message: 'Username and password required' });
   }
+  const existingUser = users.find((u) => u.username === username);
+  if (existingUser) {
+    return res.status(409).json({ message: 'Username already exists' });
+  }
   const hashedPassword = await bcrypt.hash(password, 10);
   const user: User = {
     id: nextId++,


### PR DESCRIPTION
## Summary
- prevent duplicate registrations by verifying username in `/register`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893680cd63483319c93609ec9db3664